### PR TITLE
Fix problem that caused left and right eyes to have the exact same im…

### DIFF
--- a/src/openvrupdateslavecallback.cpp
+++ b/src/openvrupdateslavecallback.cpp
@@ -20,7 +20,7 @@ void OpenVRUpdateSlaveCallback::updateSlave(osg::View& view, osg::View::Slave& s
 	osg::Matrix viewOffset = (m_cameraType == LEFT_CAMERA) ? m_device->viewMatrixLeft() : m_device->viewMatrixRight();
 
 	viewOffset.preMultRotate(orientation);
-	viewOffset.setTrans(position);
+	viewOffset.setTrans(viewOffset.getTrans() + position);
 
 	slave._viewOffset = viewOffset;
 


### PR DESCRIPTION
…age.

Hi; I was using this viewer code in my own project and it seemed like there was no 3D effect.  I then noticed that my left and right eye had basically exactly the same image.  To verify this, line up two objects in your scene that have different depths, and close your left and right eye.  You will see that the objects are perfectly aligned in both eyes, as opposed to shifting left and right a bit like they should.  After debugging for a while, I narrowed it down to the code in openvrslavecallback.cpp which reads:

void OpenVRUpdateSlaveCallback::updateSlave(osg::View& view, osg::View::Slave& slave)
{
    if (m_cameraType == LEFT_CAMERA)
    {
        m_device->updatePose();
    }

```
osg::Vec3 position = m_device->position();
osg::Quat orientation = m_device->orientation();

osg::Matrix viewOffset = (m_cameraType == LEFT_CAMERA) ? m_device->viewMatrixLeft() : m_device->viewMatrixRight();

viewOffset.preMultRotate(orientation);
viewOffset.setTrans(position);

slave._viewOffset = viewOffset;

slave.updateSlaveImplementation(view);
```

}

If you stare at it you realize that the line that says viewOffset.setTrans(position) causes both the left and right view offsets to have exactly the same translation, ignoring whatever translation is in m_device->viewMatrixLeft or m_device->viewMatrixRight.  If you change the line to:

```
viewOffset.setTrans(viewOffset.getTrans() + position)
```

it adds the translation from the device to the translation from the view offset and seems to work properly.  You now have stereo vision.

Max Behensky
